### PR TITLE
force to copy qtgui.dll

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -91,6 +91,8 @@ mkdir program\srv
     @echo on
     "C:\Qt\Qt%QT_VER%.%QT_REV%\%QT_VER%\msvc2015\bin\windeployqt.exe" --release --dir program\srv program\srv\t32bitsrv.exe
     @echo off
+    rem 25/11/2016 for unknown reasons, QtGui.dll is not copied to srv with windeployqt
+    copy /Y "C:\Qt\Qt%QT_VER%.%QT_REV%\%QT_VER%\msvc2015\bin\Qt5Gui.dll" program\srv
     if errorlevel 1 exit /b 1
 )
 


### PR DESCRIPTION
This is a quick-and-dirty fix. 
For unknown reasons, QtGui.dll is not copied to srv with windeployqt.exe so copy it manually.