### PR TITLE
Added an option to overwrite files in the Stuff folder

### DIFF
--- a/filelist.py
+++ b/filelist.py
@@ -15,7 +15,10 @@ print
 
 for path, dirs, files in os.walk(ur'stuff'):
     for file in files:
-        print >> fout, """Source: "%s"; DestDir: "{code:GetGeneralDir}%s"; Flags: onlyifdoesntexist uninsneveruninstall""" % (
+        print >> fout, """Source: "%s"; DestDir: "{code:GetGeneralDir}%s"; Flags: uninsneveruninstall; Check: IsOverwiteStuffCheckBoxChecked""" % (
+            os.path.join(path, file),
+            path[len("stuff"):])
+        print >> fout, """Source: "%s"; DestDir: "{code:GetGeneralDir}%s"; Flags: onlyifdoesntexist uninsneveruninstall; Check: not IsOverwiteStuffCheckBoxChecked""" % (
             os.path.join(path, file),
             path[len("stuff"):])
 

--- a/setup.iss
+++ b/setup.iss
@@ -75,22 +75,27 @@ Name: {code:GetGeneralDir}; Flags: uninsneveruninstall
 en.GeneralDirPageTitle=Choose Destination Location for Stuff Folder
 en.GeneralDirPageDescription=Select the folder where setup will install the OpenToonz Stuff folder containing various setting files
 en.GeneralDirPageLabel=Install the OpenToonz Stuff folder to:
+en.OverwriteStuffCheckBoxLabel=Overwrite all setting files in the Stuff folder except user's personal settings 
 
 jp.GeneralDirPageTitle=Stuffフォルダのインストール先の選択
 jp.GeneralDirPageDescription=各種設定が保存されるStuffフォルダのインストール先を選択してください
 jp.GeneralDirPageLabel=Stuffフォルダのインストール先:
+jp.OverwriteStuffCheckBoxLabel=ユーザーの個人設定以外のStuffフォルダ内の設定ファイルを全て上書きする
 
 fr.GeneralDirPageTitle=Choose Destination Location for Stuff Folder
 fr.GeneralDirPageDescription=Select the folder where setup will install the OpenToonz Stuff folder containing various setting files
 fr.GeneralDirPageLabel=Install the OpenToonz Stuff folder to:
+fr.OverwriteStuffCheckBoxLabel=Overwrite all setting files in the Stuff folder except user's personal settings 
 
 it.GeneralDirPageTitle=Choose Destination Location for Stuff Folder
 it.GeneralDirPageDescription=Select the folder where setup will install the OpenToonz Stuff folder containing various setting files
 it.GeneralDirPageLabel=Install the OpenToonz Stuff folder to:
+it.OverwriteStuffCheckBoxLabel=Overwrite all setting files in the Stuff folder except user's personal settings
 
 [Code]
 var
   GeneralDirPage: TInputDirWizardPage;
+  OverwriteStuffCheckBox: TNewCheckBox;
 
 procedure InitializeWizard;
 begin
@@ -102,9 +107,20 @@ begin
     '');
   GeneralDirPage.Add('');
   GeneralDirPage.Values[0] := 'C:\OpenToonz 1.1 stuff';
+  OverwriteStuffCheckBox := TNewCheckBox.Create(GeneralDirPage);
+  OverwriteStuffCheckBox.Caption := CustomMessage('OverwriteStuffCheckBoxLabel');
+  OverwriteStuffCheckBox.Parent := GeneralDirPage.Surface;
+  OverwriteStuffCheckBox.Top := 70;
+  OverwriteStuffCheckBox.Width := GeneralDirPage.SurfaceWidth;
+  OverwriteStuffCheckBox.Checked := False;
 end;
 
 function GetGeneralDir(Param: String): String;
 begin
   Result := GeneralDirPage.Values[0];
+end;
+
+function IsOverwiteStuffCheckBoxChecked: Boolean;
+begin
+  Result := OverwriteStuffCheckBox.Checked;
 end;


### PR DESCRIPTION
This PR is for the issue [opentoonz/#1091](https://github.com/opentoonz/opentoonz/issues/1091).
For now, uninstalling the software does not delete the contents of the Stuff folder, and installing the software does not overwrite the data in the Stuff folder in considering that the contents of Stuff folder may be customized by user during use.

I added a check box which allows installer to overwrite all the setting files in the Stuff folder.
Even there is a risk to overwrite a user-customized file (such as style files, reslist.txt etc.), but this option would be useful for quite a number of users who use the software without modifying non-personal settings.