### PR TITLE
Fix UI position for high dpi monitors

### DIFF
--- a/setup.iss
+++ b/setup.iss
@@ -110,7 +110,7 @@ begin
   OverwriteStuffCheckBox := TNewCheckBox.Create(GeneralDirPage);
   OverwriteStuffCheckBox.Caption := CustomMessage('OverwriteStuffCheckBoxLabel');
   OverwriteStuffCheckBox.Parent := GeneralDirPage.Surface;
-  OverwriteStuffCheckBox.Top := 70;
+  OverwriteStuffCheckBox.Top := ScaleY(70);
   OverwriteStuffCheckBox.Width := GeneralDirPage.SurfaceWidth;
   OverwriteStuffCheckBox.Checked := False;
 end;


### PR DESCRIPTION
This will fix the problem that the `Overwrite all setting files in the Stuff folder except user's personal settings` checkbox is placed at wrong position when using high dpi monitors.
Confirmed fix with MobileStudioPro13.