### PR TITLE
filelist.py for Python3

### DIFF
--- a/filelist_python3.py
+++ b/filelist_python3.py
@@ -1,0 +1,26 @@
+# list up files in program and stuff
+# for python version 3.x (converted with 2to3.py from filelist.py)
+
+import os
+import codecs
+
+fout = codecs.open("files.iss", "w", "utf_8_sig")
+
+for path, dirs, files in os.walk(r'program'):
+    for file in files:
+        print("""Source: "%s"; DestDir: "{app}%s"; Flags: ignoreversion""" % (
+            os.path.join(path, file),
+            path[len("program"):]), file=fout)
+
+print()
+
+for path, dirs, files in os.walk(r'stuff'):
+    for file in files:
+        print("""Source: "%s"; DestDir: "{code:GetGeneralDir}%s"; Flags: uninsneveruninstall; Check: IsOverwiteStuffCheckBoxChecked""" % (
+            os.path.join(path, file),
+            path[len("stuff"):]), file=fout)
+        print("""Source: "%s"; DestDir: "{code:GetGeneralDir}%s"; Flags: onlyifdoesntexist uninsneveruninstall; Check: not IsOverwiteStuffCheckBoxChecked""" % (
+            os.path.join(path, file),
+            path[len("stuff"):]), file=fout)
+
+fout.close()

--- a/setup_v2.bat
+++ b/setup_v2.bat
@@ -102,7 +102,7 @@ xcopy /YE ..\stuff stuff
 xcopy /YE ..\toonz\build\loc stuff\config\loc
 for /R %%F in (.gitkeep) do del "%%F"
 
-python filelist.py
+python filelist_python3.py
 "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" setup.iss
 if errorlevel 1 exit /b 1
 


### PR DESCRIPTION
This PR will add a compatible file of `filelist.py` for running on Python 3.x .
`filelist_python3.py` is simply made from the original `filelist.py` with the python tool `2to3.py` .