### PR TITLE
Fix missing Qt5Widgets.dll in SRV folder

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -97,6 +97,7 @@ mkdir program\srv
     @echo off
     rem 25/11/2016 for unknown reasons, QtGui.dll is not copied to srv with windeployqt
     copy /Y "C:\Qt\Qt%QT_VER%.%QT_REV%\%QT_VER%\msvc2015\bin\Qt5Gui.dll" program\srv\Qt5Gui.dll
+    copy /Y "C:\Qt\Qt%QT_VER%.%QT_REV%\%QT_VER%\msvc2015\bin\Qt5Widgets.dll" program\srv\Qt5Widgets.dll
     if errorlevel 1 exit /b 1
 )
 


### PR DESCRIPTION
This fixes the issue of OT failing to start due to a missing 32-bit DLL in the SRV folder.

The 64-bit version of Qt5Widgets.dll was introduced into the OT build, but the 32-bit version also needed to be included in the release for MOV via Quicktime support.